### PR TITLE
Fix message for say input color toggle

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1974,11 +1974,11 @@ GLOBAL_LIST_INIT(be_special_flags, list(
 					if(!result)
 						return
 					if(result == "Lightmode")
-						tgui_say_light_mode = TRUE
-						to_chat(user, SPAN_NOTICE("You're now using the say interface whitemode."))
+					tgui_say_light_mode = TRUE
+					to_chat(user, SPAN_NOTICE("You're now using the say interface light mode."))
 					else
-						tgui_say_light_mode = FALSE
-						to_chat(user, SPAN_NOTICE("You're now using the say interface darkmode."))
+					tgui_say_light_mode = FALSE
+					to_chat(user, SPAN_NOTICE("You're now using the say interface dark mode."))
 					user?.client.tgui_say?.load()
 					save_preferences()
 

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -549,13 +549,13 @@
 
 	var/result = tgui_alert(src, "Which input color do you want?", "Input Style", list("Darkmode", "Lightmode"))
 	if(!result)
-		return
+	return
 	if(result == "Lightmode")
-		prefs.tgui_say_light_mode = TRUE
-		to_chat(src, SPAN_NOTICE("You're now using the say interface whitemode."))
+	prefs.tgui_say_light_mode = TRUE
+	to_chat(src, SPAN_NOTICE("You're now using the say interface light mode."))
 	else
-		prefs.tgui_say_light_mode = FALSE
-		to_chat(src, SPAN_NOTICE("You're now using the say interface whitemode."))
+	prefs.tgui_say_light_mode = FALSE
+	to_chat(src, SPAN_NOTICE("You're now using the say interface dark mode."))
 	tgui_say?.load()
 	prefs.save_preferences()
 

--- a/html/changelogs/codexfix-say-input-color.yml
+++ b/html/changelogs/codexfix-say-input-color.yml
@@ -1,3 +1,2 @@
-author: "codex"
 changes:
   - spellcheck: "Corrected say interface color toggle messages to refer to light and dark modes appropriately."

--- a/html/changelogs/codexfix-say-input-color.yml
+++ b/html/changelogs/codexfix-say-input-color.yml
@@ -1,0 +1,3 @@
+author: "codex"
+changes:
+  - spellcheck: "Corrected say interface color toggle messages to refer to light and dark modes appropriately."


### PR DESCRIPTION
## Summary
- correct the player message when toggling the say interface light/dark mode
- add a changelog entry

## Testing
- `bash tools/ci/check_grep.sh`
- `bash tools/ci/check_misc.sh` *(fails: `php` not found)*
- `bash tools/ci/check_changelogs.sh` *(fails: missing `yaml` module)*

------
https://chatgpt.com/codex/tasks/task_e_68489947db20832981582f3b8a7f5542